### PR TITLE
[Feat] 쿠폰 API

### DIFF
--- a/common/common-application/src/main/java/com/project/imdang/application/handler/ErrorDTO.java
+++ b/common/common-application/src/main/java/com/project/imdang/application/handler/ErrorDTO.java
@@ -2,6 +2,7 @@ package com.project.imdang.application.handler;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class ErrorDTO {
@@ -9,8 +10,15 @@ public class ErrorDTO {
     private final String message;
 
     @Builder
-    public ErrorDTO(String code, String message) {
+    private ErrorDTO(String code, String message) {
         this.code = code;
         this.message = message;
+    }
+
+    public static ErrorDTO of(HttpStatus status, String message) {
+        return ErrorDTO.builder()
+                .code(status.getReasonPhrase())
+                .message(message)
+                .build();
     }
 }

--- a/insight-service/insight-application/src/main/java/com/project/imdang/insight/service/application/exception/handler/InsightGlobalExceptionHandler.java
+++ b/insight-service/insight-application/src/main/java/com/project/imdang/insight/service/application/exception/handler/InsightGlobalExceptionHandler.java
@@ -20,10 +20,7 @@ public class InsightGlobalExceptionHandler extends GlobalExceptionHandler {
     public ErrorDTO handleException(InsightDomainException insightDomainException) {
         String message = insightDomainException.getMessage();
         log.error(message, insightDomainException);
-        return ErrorDTO.builder()
-                .code(HttpStatus.BAD_REQUEST.getReasonPhrase())
-                .message(message)
-                .build();
+        return ErrorDTO.of(HttpStatus.BAD_REQUEST, message);
     }
 
     @ResponseBody
@@ -32,9 +29,6 @@ public class InsightGlobalExceptionHandler extends GlobalExceptionHandler {
     public ErrorDTO handleException(InsightNotFoundException insightNotFoundException) {
         String message = insightNotFoundException.getMessage();
         log.error(message, insightNotFoundException);
-        return ErrorDTO.builder()
-                .code(HttpStatus.NOT_FOUND.getReasonPhrase())
-                .message(message)
-                .build();
+        return ErrorDTO.of(HttpStatus.NOT_FOUND, message);
     }
 }

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/CouponGlobalExceptionHandler.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/CouponGlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.project.imdang.member.service.application.exception.handler;
+
+import com.project.imdang.application.handler.ErrorDTO;
+import com.project.imdang.member.service.domain.exception.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Slf4j
+@ControllerAdvice
+public class CouponGlobalExceptionHandler extends GlobalExceptionHandler {
+
+    @ResponseBody
+    @ExceptionHandler(value = {CouponDomainException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorDTO handleException(CouponDomainException couponDomainException) {
+        String message = couponDomainException.getMessage();
+        log.error(message, couponDomainException);
+        return ErrorDTO.of(HttpStatus.BAD_REQUEST, message);
+    }
+
+
+    @ResponseBody
+    @ExceptionHandler(value = {CouponNotFoundException.class})
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorDTO handleException(CouponNotFoundException couponNotFoundException) {
+        String message = couponNotFoundException.getMessage();
+        log.error(message, couponNotFoundException);
+        return ErrorDTO.of(HttpStatus.NOT_FOUND, message);
+    }
+
+}

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/GlobalExceptionHandler.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.project.imdang.insight.service.application.exception.handler;
+package com.project.imdang.member.service.application.exception.handler;
 
 import com.project.imdang.application.handler.ErrorDTO;
 import jakarta.validation.ConstraintViolation;
@@ -33,7 +33,9 @@ public class GlobalExceptionHandler {
         if (validationException instanceof ConstraintViolationException) {
             String violations = extractViolationsFromException((ConstraintViolationException) validationException);
             log.error(violations, validationException);
+
             errorDTO = ErrorDTO.of(HttpStatus.BAD_REQUEST, violations);
+
         } else {
             String exceptionMessage = validationException.getMessage();
             log.error(exceptionMessage, validationException);

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/GlobalExceptionHandler.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @ControllerAdvice
+@Component("MemberGlobalExceptionHandler")
 public class GlobalExceptionHandler {
 
     @ResponseBody

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/MemberCouponGlobalExceptionHandler.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/MemberCouponGlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.project.imdang.member.service.application.exception.handler;
+
+import com.project.imdang.application.handler.ErrorDTO;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.exception.MemberCouponNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Slf4j
+@ControllerAdvice
+public class MemberCouponGlobalExceptionHandler extends GlobalExceptionHandler {
+
+    @ResponseBody
+    @ExceptionHandler(value = {MemberCouponDomainException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorDTO handleException(MemberCouponDomainException memberCouponDomainException) {
+        String message = memberCouponDomainException.getMessage();
+        log.error(message, memberCouponDomainException);
+        return ErrorDTO.of(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(value = {MemberCouponNotFoundException.class})
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorDTO handleException(MemberCouponNotFoundException memberCouponNotFoundException) {
+        String message = memberCouponNotFoundException.getMessage();
+        log.error(message, memberCouponNotFoundException);
+        return ErrorDTO.of(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/MemberGlobalExceptionHandler.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/exception/handler/MemberGlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.project.imdang.member.service.application.exception.handler;
+
+import com.project.imdang.application.handler.ErrorDTO;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.exception.MemberCouponNotFoundException;
+import com.project.imdang.member.service.domain.exception.MemberDomainException;
+import com.project.imdang.member.service.domain.exception.MemberNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Slf4j
+@ControllerAdvice
+public class MemberGlobalExceptionHandler extends GlobalExceptionHandler {
+
+    @ResponseBody
+    @ExceptionHandler(value = {MemberDomainException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorDTO handleException(MemberDomainException memberDomainException) {
+        String message = memberDomainException.getMessage();
+        log.error(message, memberDomainException);
+        return ErrorDTO.of(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(value = {MemberCouponNotFoundException.class})
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorDTO handleException(MemberNotFoundException memberNotFoundException) {
+        String message = memberNotFoundException.getMessage();
+        log.error(message, memberNotFoundException);
+        return ErrorDTO.of(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/rest/CouponController.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/rest/CouponController.java
@@ -1,0 +1,62 @@
+package com.project.imdang.member.service.application.rest;
+
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.dto.LoginResponse;
+import com.project.imdang.member.service.domain.dto.coupon.*;
+import com.project.imdang.member.service.domain.ports.input.service.MemberCouponApplicationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "CouponController", description = "쿠폰 API")
+@RequestMapping("/coupons")
+@Slf4j
+public class CouponController {
+
+    private final MemberCouponApplicationService memberCouponApplicationService;
+
+    @Operation(description = "쿠폰 개수(목록) 조회 API")
+    @ApiResponse(responseCode = "200", description = "쿠폰 개수 조회 성공",
+            content = @Content(schema = @Schema(implementation = ListMemberCouponResponse.class)))
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ListMemberCouponResponse> list(@PathVariable("memberId") UUID memberId) {
+        ListMemberCouponResponse listMemberCouponResponse = memberCouponApplicationService.listMemberCoupon(memberId);
+        return ResponseEntity.ok(listMemberCouponResponse);
+    }
+
+    @Operation(description = "쿠폰 발행 API")
+    @ApiResponse(responseCode = "200", description = "쿠폰 발행 성공")
+    @PostMapping("/issue")
+    public ResponseEntity<Void> issueCoupon(@RequestBody IssueMemberCouponCommand issueMemberCouponCommand) {
+        memberCouponApplicationService.issueMemberCoupon(issueMemberCouponCommand);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(description = "쿠폰 사용 API")
+    @ApiResponse(responseCode = "200", description = "쿠폰 사용 성공",
+            content = @Content(schema = @Schema(implementation = UseMemberCouponCommandResponse.class))
+    )
+    @PostMapping("/use")
+    public ResponseEntity<UseMemberCouponCommandResponse> useCoupon(@RequestBody UseMemberCouponCommand useMemberCouponCommand) {
+        UseMemberCouponCommandResponse useMemberCouponCommandResponse = memberCouponApplicationService.useMemberCoupon(useMemberCouponCommand);
+        return ResponseEntity.ok(useMemberCouponCommandResponse);
+    }
+
+    @Operation(description = "쿠폰 사용 취소 API")
+    @ApiResponse(responseCode = "200", description = "쿠폰 사용 취소 성공")
+    @PostMapping("/cancle")
+    public ResponseEntity<Void> cancleCoupon(@RequestBody CancleMemberCouponCommand cancleMemberCouponCommand) {
+        memberCouponApplicationService.cancleMemberCoupon(cancleMemberCouponCommand);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/member-service/member-application/src/main/java/com/project/imdang/member/service/application/rest/CouponController.java
+++ b/member-service/member-application/src/main/java/com/project/imdang/member/service/application/rest/CouponController.java
@@ -1,7 +1,5 @@
 package com.project.imdang.member.service.application.rest;
 
-import com.project.imdang.domain.valueobject.MemberId;
-import com.project.imdang.member.service.domain.dto.LoginResponse;
 import com.project.imdang.member.service.domain.dto.coupon.*;
 import com.project.imdang.member.service.domain.ports.input.service.MemberCouponApplicationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,9 +52,9 @@ public class CouponController {
 
     @Operation(description = "쿠폰 사용 취소 API")
     @ApiResponse(responseCode = "200", description = "쿠폰 사용 취소 성공")
-    @PostMapping("/cancle")
-    public ResponseEntity<Void> cancleCoupon(@RequestBody CancleMemberCouponCommand cancleMemberCouponCommand) {
-        memberCouponApplicationService.cancleMemberCoupon(cancleMemberCouponCommand);
+    @PostMapping("/cancel")
+    public ResponseEntity<Void> cancelCoupon(@RequestBody CancelMemberCouponCommand cancelMemberCouponCommand) {
+        memberCouponApplicationService.cancleMemberCoupon(cancelMemberCouponCommand);
         return ResponseEntity.ok().build();
     }
 }

--- a/member-service/member-container/src/main/java/com/project/imdang/member/service/BeanConfiguration.java
+++ b/member-service/member-container/src/main/java/com/project/imdang/member/service/BeanConfiguration.java
@@ -1,5 +1,7 @@
 package com.project.imdang.member.service;
 
+import com.project.imdang.member.service.domain.MemberCouponDomainService;
+import com.project.imdang.member.service.domain.MemberCouponDomainServiceImpl;
 import com.project.imdang.member.service.domain.MemberDomainService;
 import com.project.imdang.member.service.domain.MemberDomainServiceImpl;
 import org.springframework.context.annotation.Bean;
@@ -16,5 +18,10 @@ public class BeanConfiguration {
     @Bean
     public MemberDomainService memberDomainService() {
         return new MemberDomainServiceImpl();
+    }
+
+    @Bean
+    public MemberCouponDomainService memberCouponDomainService() {
+        return new MemberCouponDomainServiceImpl();
     }
 }

--- a/member-service/member-container/src/test/java/rest/CouponControllerTest.java
+++ b/member-service/member-container/src/test/java/rest/CouponControllerTest.java
@@ -1,0 +1,149 @@
+package rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.persistence.entity.CouponEntity;
+import com.project.imdang.member.persistence.repository.CouponJpaRespository;
+import com.project.imdang.member.service.domain.dto.coupon.IssueMemberCouponCommand;
+import com.project.imdang.member.service.domain.dto.coupon.UseMemberCouponCommand;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import com.project.imdang.member.service.domain.ports.output.MemberRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = TestConfiguration.class)
+class CouponControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MemberCouponRepository memberCouponRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CouponJpaRespository couponJpaRespository;
+
+    static final UUID memberId = UUID.randomUUID();
+
+    @BeforeEach
+    void initialize() {
+        memberRepository.save(Member.builder()
+                .id(new MemberId(memberId))
+                .nickname("imdang").build());
+    }
+
+
+    @Transactional
+    @Test
+    void list() throws Exception{
+        //given
+        memberCouponRepository.saveAll(IntStream.range(0, 3)
+                        .mapToObj(i -> {
+                            return MemberCoupon.builder()
+                                    .couponId(new CouponId(UUID.randomUUID()))
+                                    .used(Boolean.FALSE)
+                                    .memberId(new MemberId(memberId))
+                                    .createdAt(ZonedDateTime.now()).build();
+                        }).collect(Collectors.toList()));
+        //when
+        //then
+        mockMvc.perform(get("/coupons/{memberId}", memberId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.couponCount").value(3))
+                .andDo(print())
+                .andReturn();
+    }
+
+    @Transactional
+    @Test
+    void issueCoupon() throws Exception {
+        //given
+        UUID couponId = UUID.randomUUID();
+        couponJpaRespository.save(CouponEntity.builder()
+                        .id(couponId).name("Welcome").build());
+
+        IssueMemberCouponCommand issueMemberCouponCommand = new IssueMemberCouponCommand(memberId, couponId);
+
+        //when
+        //then
+        mockMvc.perform(post("/coupons/issue")
+                        .content(objectMapper.writeValueAsString(issueMemberCouponCommand))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+    }
+
+    @Test
+    @Transactional
+    void useCoupon() throws Exception{
+        //given
+        memberCouponRepository.saveAll(IntStream.range(0, 3)
+                .mapToObj(i -> {
+                    return MemberCoupon.builder()
+                            .couponId(new CouponId(UUID.randomUUID()))
+                            .used(Boolean.FALSE)
+                            .memberId(new MemberId(memberId))
+                            .createdAt(ZonedDateTime.now()).build();
+                }).collect(Collectors.toList()));
+
+        UseMemberCouponCommand useMemberCouponCommand = new UseMemberCouponCommand(memberId);
+
+        //when
+        //then
+        mockMvc.perform(post("/coupons/use")
+                        .content(objectMapper.writeValueAsString(useMemberCouponCommand))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberCouponId").value(1))
+                .andDo(print())
+                .andReturn();
+    }
+
+    @Test
+    @Transactional
+    void useCouponErrorCase() throws Exception{
+        //given
+        memberCouponRepository.saveAll(IntStream.range(0, 3)
+                .mapToObj(i -> {
+                    return MemberCoupon.builder()
+                            .couponId(new CouponId(UUID.randomUUID()))
+                            .used(Boolean.TRUE)
+                            .memberId(new MemberId(memberId))
+                            .createdAt(ZonedDateTime.now()).build();
+                }).collect(Collectors.toList()));
+
+        UseMemberCouponCommand useMemberCouponCommand = new UseMemberCouponCommand(memberId);
+
+        //when
+        //then
+        mockMvc.perform(post("/coupons/use")
+                        .content(objectMapper.writeValueAsString(useMemberCouponCommand))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andReturn();
+    }
+}

--- a/member-service/member-container/src/test/java/rest/TestConfiguration.java
+++ b/member-service/member-container/src/test/java/rest/TestConfiguration.java
@@ -1,0 +1,11 @@
+package rest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = "com.project.imdang")
+@EnableJpaRepositories(basePackages = "com.project.imdang.member.persistence")
+@EntityScan(basePackages = "com.project.imdang.member.persistence")
+public class TestConfiguration {
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/MemberCouponApplicationServiceImpl.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/MemberCouponApplicationServiceImpl.java
@@ -1,0 +1,41 @@
+package com.project.imdang.member.service.domain;
+
+import com.project.imdang.member.service.domain.dto.coupon.*;
+import com.project.imdang.member.service.domain.handler.coupon.CancleMemberCouponCommandHandler;
+import com.project.imdang.member.service.domain.handler.coupon.IssueMemberCouponCommandHandler;
+import com.project.imdang.member.service.domain.handler.coupon.ListMemberCouponHandler;
+import com.project.imdang.member.service.domain.handler.coupon.UseMemberCouponCommandHandler;
+import com.project.imdang.member.service.domain.ports.input.service.MemberCouponApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCouponApplicationServiceImpl implements MemberCouponApplicationService {
+
+    private final IssueMemberCouponCommandHandler issueMemberCouponCommandHandler;
+    private final UseMemberCouponCommandHandler useMemberCouponCommandHandler;
+    private final CancleMemberCouponCommandHandler cancleMemberCouponCommandHandler;
+    private final ListMemberCouponHandler listMemberCouponHandler;
+    @Override
+    public ListMemberCouponResponse listMemberCoupon(UUID memberId) {
+        return listMemberCouponHandler.list(memberId);
+    }
+
+    @Override
+    public void issueMemberCoupon(IssueMemberCouponCommand issueMemberCouponCommand) {
+        issueMemberCouponCommandHandler.issue(issueMemberCouponCommand);
+    }
+
+    @Override
+    public UseMemberCouponCommandResponse useMemberCoupon(UseMemberCouponCommand useMemberCouponCommand) {
+        return useMemberCouponCommandHandler.use(useMemberCouponCommand);
+    }
+
+    @Override
+    public void cancleMemberCoupon(CancleMemberCouponCommand cancleMemberCouponCommand) {
+        cancleMemberCouponCommandHandler.cancle(cancleMemberCouponCommand);
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/MemberCouponApplicationServiceImpl.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/MemberCouponApplicationServiceImpl.java
@@ -1,7 +1,7 @@
 package com.project.imdang.member.service.domain;
 
 import com.project.imdang.member.service.domain.dto.coupon.*;
-import com.project.imdang.member.service.domain.handler.coupon.CancleMemberCouponCommandHandler;
+import com.project.imdang.member.service.domain.handler.coupon.CancelMemberCouponCommandHandler;
 import com.project.imdang.member.service.domain.handler.coupon.IssueMemberCouponCommandHandler;
 import com.project.imdang.member.service.domain.handler.coupon.ListMemberCouponHandler;
 import com.project.imdang.member.service.domain.handler.coupon.UseMemberCouponCommandHandler;
@@ -17,7 +17,7 @@ public class MemberCouponApplicationServiceImpl implements MemberCouponApplicati
 
     private final IssueMemberCouponCommandHandler issueMemberCouponCommandHandler;
     private final UseMemberCouponCommandHandler useMemberCouponCommandHandler;
-    private final CancleMemberCouponCommandHandler cancleMemberCouponCommandHandler;
+    private final CancelMemberCouponCommandHandler cancelMemberCouponCommandHandler;
     private final ListMemberCouponHandler listMemberCouponHandler;
     @Override
     public ListMemberCouponResponse listMemberCoupon(UUID memberId) {
@@ -35,7 +35,7 @@ public class MemberCouponApplicationServiceImpl implements MemberCouponApplicati
     }
 
     @Override
-    public void cancleMemberCoupon(CancleMemberCouponCommand cancleMemberCouponCommand) {
-        cancleMemberCouponCommandHandler.cancle(cancleMemberCouponCommand);
+    public void cancleMemberCoupon(CancelMemberCouponCommand cancelMemberCouponCommand) {
+        cancelMemberCouponCommandHandler.cancle(cancelMemberCouponCommand);
     }
 }

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/CancelMemberCouponCommand.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/CancelMemberCouponCommand.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class CancleMemberCouponCommand {
+public class CancelMemberCouponCommand {
      private Long memberCouponId;
 }
 

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/CancleMemberCouponCommand.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/CancleMemberCouponCommand.java
@@ -1,0 +1,14 @@
+package com.project.imdang.member.service.domain.dto.coupon;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CancleMemberCouponCommand {
+     private Long memberCouponId;
+}
+

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/IssueMemberCouponCommand.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/IssueMemberCouponCommand.java
@@ -1,0 +1,16 @@
+package com.project.imdang.member.service.domain.dto.coupon;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueMemberCouponCommand {
+    private UUID memberId;
+    private UUID couponId;
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/ListMemberCouponResponse.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/ListMemberCouponResponse.java
@@ -1,0 +1,16 @@
+package com.project.imdang.member.service.domain.dto.coupon;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ListMemberCouponResponse {
+    @Schema(description = "보유한 쿠폰 갯수")
+    private Integer couponCount;
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/UseMemberCouponCommand.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/UseMemberCouponCommand.java
@@ -1,0 +1,13 @@
+package com.project.imdang.member.service.domain.dto.coupon;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UseMemberCouponCommand {
+     private UUID memberId;
+}
+

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/UseMemberCouponCommandResponse.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/dto/coupon/UseMemberCouponCommandResponse.java
@@ -1,0 +1,18 @@
+package com.project.imdang.member.service.domain.dto.coupon;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UseMemberCouponCommandResponse {
+     @Schema(description = "사용한 쿠폰ID")
+     private Long memberCouponId;
+}
+

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/CancelMemberCouponCommandHandler.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/CancelMemberCouponCommandHandler.java
@@ -2,7 +2,7 @@ package com.project.imdang.member.service.domain.handler.coupon;
 
 import com.project.imdang.domain.valueobject.MemberCouponId;
 import com.project.imdang.member.service.domain.MemberCouponDomainService;
-import com.project.imdang.member.service.domain.dto.coupon.CancleMemberCouponCommand;
+import com.project.imdang.member.service.domain.dto.coupon.CancelMemberCouponCommand;
 import com.project.imdang.member.service.domain.entity.MemberCoupon;
 import com.project.imdang.member.service.domain.exception.MemberCouponNotFoundException;
 import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
@@ -14,13 +14,13 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class CancleMemberCouponCommandHandler {
+public class CancelMemberCouponCommandHandler {
     private final MemberCouponRepository memberCouponRepository;
     private final MemberCouponDomainService memberCouponDomainService;
 
-    public void cancle(CancleMemberCouponCommand cancleMemberCouponCommand) {
+    public void cancle(CancelMemberCouponCommand cancelMemberCouponCommand) {
         // 1. 쿠폰 조회
-        MemberCoupon memberCoupon = checkMemberCoupon(cancleMemberCouponCommand.getMemberCouponId());
+        MemberCoupon memberCoupon = checkMemberCoupon(cancelMemberCouponCommand.getMemberCouponId());
         // 2. 쿠폰 취소
         memberCouponDomainService.cancle(memberCoupon);
         log.info("MemberCoupon[id:{}] is cancled", memberCoupon.getId().getValue());

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/CancleMemberCouponCommandHandler.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/CancleMemberCouponCommandHandler.java
@@ -1,0 +1,34 @@
+package com.project.imdang.member.service.domain.handler.coupon;
+
+import com.project.imdang.domain.valueobject.MemberCouponId;
+import com.project.imdang.member.service.domain.MemberCouponDomainService;
+import com.project.imdang.member.service.domain.dto.coupon.CancleMemberCouponCommand;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import com.project.imdang.member.service.domain.exception.MemberCouponNotFoundException;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CancleMemberCouponCommandHandler {
+    private final MemberCouponRepository memberCouponRepository;
+    private final MemberCouponDomainService memberCouponDomainService;
+
+    public void cancle(CancleMemberCouponCommand cancleMemberCouponCommand) {
+        // 1. 쿠폰 조회
+        MemberCoupon memberCoupon = checkMemberCoupon(cancleMemberCouponCommand.getMemberCouponId());
+        // 2. 쿠폰 취소
+        memberCouponDomainService.cancle(memberCoupon);
+        log.info("MemberCoupon[id:{}] is cancled", memberCoupon.getId().getValue());
+    }
+
+    private MemberCoupon checkMemberCoupon(Long _memberCouponId) {
+        MemberCouponId memberCouponId = new MemberCouponId(_memberCouponId);
+        return memberCouponRepository.findById(memberCouponId)
+                .orElseThrow(() -> new MemberCouponNotFoundException(memberCouponId));
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/IssueMemberCouponCommandHandler.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/IssueMemberCouponCommandHandler.java
@@ -1,0 +1,86 @@
+package com.project.imdang.member.service.domain.handler.coupon;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.MemberCouponDomainService;
+import com.project.imdang.member.service.domain.dto.coupon.IssueMemberCouponCommand;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import com.project.imdang.member.service.domain.exception.CouponNotFoundException;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.exception.MemberNotFoundException;
+import com.project.imdang.member.service.domain.handler.coupon.policy.CouponPolicy;
+import com.project.imdang.member.service.domain.mapper.MemberCouponDataMapper;
+import com.project.imdang.member.service.domain.ports.output.CouponRepository;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import com.project.imdang.member.service.domain.ports.output.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class IssueMemberCouponCommandHandler {
+    private final MemberCouponDataMapper memberCouponDataMapper;
+    private final MemberCouponRepository memberCouponRepository;
+    private final CouponRepository couponRepository;
+    private final MemberRepository memberRepository;
+    private final MemberCouponDomainService memberCouponDomainService;
+    private final Map<String, CouponPolicy> couponPolicies;
+
+    public IssueMemberCouponCommandHandler(MemberCouponDataMapper memberCouponDataMapper, MemberCouponRepository memberCouponRepository, CouponRepository couponRepository, MemberRepository memberRepository, MemberCouponDomainService memberCouponDomainService, List<CouponPolicy> couponPolicies) {
+        this.memberCouponDataMapper = memberCouponDataMapper;
+        this.memberCouponRepository = memberCouponRepository;
+        this.couponRepository = couponRepository;
+        this.memberRepository = memberRepository;
+        this.memberCouponDomainService = memberCouponDomainService;
+        this.couponPolicies = couponPolicies.stream()
+                .collect(Collectors.toMap(couponPolicy ->
+                                couponPolicy.getClass().getAnnotation(Component.class).value(),
+                        Function.identity()));
+    }
+
+    public void issue(IssueMemberCouponCommand issueMemberCouponCommand) {
+        // 1. 쿠폰 종류 확인
+        Coupon coupon = checkCoupon(issueMemberCouponCommand.getCouponId());
+        // 2. 사용자 확인
+        Member member = checkMember(issueMemberCouponCommand.getMemberId());
+        // 3. 쿠폰 정책 적용
+        Integer couponQuantity = couponPolicies.get(coupon.getName()).apply(coupon, member);
+        // 4. 쿠폰 발급
+        List<MemberCoupon> memberCoupons = memberCouponDataMapper.issueMemberCouponCommandToMemberCoupons(member, coupon, couponQuantity);
+        memberCoupons.forEach(memberCouponDomainService::issue);
+        // 5. 쿠폰 저장
+        save(memberCoupons);
+        log.info("MemberCoupons are issued by Member[id:{}].", member.getId().getValue());
+    }
+
+    private List<MemberCoupon> save(List<MemberCoupon> memberCoupons) {
+        List<MemberCoupon> saved = memberCouponRepository.saveAll(memberCoupons);
+        if (saved.isEmpty()) {
+            String errorMessage = "Could not save memberCoupons!";
+            log.error(errorMessage);
+            throw new MemberCouponDomainException(errorMessage);
+        }
+        saved.forEach(coupon -> log.info("MemberCoupon[id: {}] is saved.", coupon.getId().getValue()));
+        return saved;
+    }
+
+    private Coupon checkCoupon(UUID _couponId) {
+        CouponId couponId = new CouponId(_couponId);
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> new CouponNotFoundException(couponId));
+    }
+
+    private Member checkMember(UUID _memberId) {
+        MemberId memberId = new MemberId(_memberId);
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/ListMemberCouponHandler.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/ListMemberCouponHandler.java
@@ -1,0 +1,40 @@
+package com.project.imdang.member.service.domain.handler.coupon;
+
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.dto.coupon.ListMemberCouponResponse;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import com.project.imdang.member.service.domain.exception.MemberNotFoundException;
+import com.project.imdang.member.service.domain.mapper.MemberCouponDataMapper;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import com.project.imdang.member.service.domain.ports.output.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ListMemberCouponHandler {
+
+    private final MemberRepository memberRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final MemberCouponDataMapper memberCouponDataMapper;
+
+    public ListMemberCouponResponse list(UUID memberId) {
+        //TODO : 추후 페이징 처리
+        Member member = checkMember(memberId);
+        // MemberCoupon 조회
+        List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberIdAndUsed(member.getId(), Boolean.FALSE);
+        log.info("");
+        return memberCouponDataMapper.memberCouponsToListMemberCouponResponse(memberCoupons);
+    }
+    private Member checkMember(UUID _memberId) {
+        MemberId memberId = new MemberId(_memberId);
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/UseMemberCouponCommandHandler.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/UseMemberCouponCommandHandler.java
@@ -1,0 +1,45 @@
+package com.project.imdang.member.service.domain.handler.coupon;
+
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.MemberCouponDomainService;
+import com.project.imdang.member.service.domain.dto.coupon.UseMemberCouponCommand;
+import com.project.imdang.member.service.domain.dto.coupon.UseMemberCouponCommandResponse;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.mapper.MemberCouponDataMapper;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UseMemberCouponCommandHandler {
+    private final MemberCouponRepository memberCouponRepository;
+    private final MemberCouponDomainService memberCouponDomainService;
+    private final MemberCouponDataMapper memberCouponDataMapper;
+
+    public UseMemberCouponCommandResponse use(UseMemberCouponCommand useMemberCouponCommand) {
+        // 1. 쿠폰 조회
+        MemberCoupon memberCoupon = checkMemberCoupon(useMemberCouponCommand.getMemberId());
+        // 2. 쿠폰 사용
+        memberCouponDomainService.use(memberCoupon);
+        log.info("MemberCoupon[id:{}] is used", memberCoupon.getId().getValue());
+        return memberCouponDataMapper.memberCouponToUseMemberCouponResponse(memberCoupon);
+    }
+
+    private MemberCoupon checkMemberCoupon(UUID _memberId) {
+        MemberId memberId = new MemberId(_memberId);
+        List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberIdAndUsed(memberId, Boolean.FALSE);
+        if (memberCoupons.isEmpty()) {
+            String errorMessage = "No more coupons available!";
+            log.info(errorMessage);
+            throw new MemberCouponDomainException(errorMessage);
+        }
+        return memberCoupons.get(0);
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/CouponPolicy.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/CouponPolicy.java
@@ -1,0 +1,11 @@
+package com.project.imdang.member.service.domain.handler.coupon.policy;
+
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+
+public interface CouponPolicy {
+
+    Integer apply(Coupon coupon, Member member);
+
+    void validate(Coupon coupon, Member member);
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/FirstCheerUpCouponPolicy.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/FirstCheerUpCouponPolicy.java
@@ -1,0 +1,47 @@
+package com.project.imdang.member.service.domain.handler.coupon.policy;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.exception.MemberNotFoundException;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import com.project.imdang.member.service.domain.ports.output.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("FirstCheerUp")
+@RequiredArgsConstructor
+public class FirstCheerUpCouponPolicy implements CouponPolicy{
+    private static final Integer REJECT_CRITERIA = 5;
+    private static final Integer ISSUE_QUANTITY = 1;
+    private final MemberCouponRepository memberCouponRepository;
+
+
+    @Override
+    public Integer apply(Coupon coupon, Member member) {
+        validate(coupon, member);
+        return ISSUE_QUANTITY;
+    }
+
+    @Override
+    public void validate(Coupon coupon, Member member) {
+        checkRejectCount(member);
+        checkReissue(coupon.getId(), member.getId());
+    }
+
+    private Boolean checkReissue(CouponId couponId, MemberId memberId) {
+        if(memberCouponRepository.findByCouponIdAndMemberId(couponId, memberId).isPresent()){
+            throw new MemberCouponDomainException("Already issued Coupon!");
+        }
+        return Boolean.TRUE;
+    }
+
+    private Boolean checkRejectCount(Member member) {
+        if (member.getRejectedCount() < REJECT_CRITERIA) {
+            throw new MemberCouponDomainException("Reject Count does not meet criteria");
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/JoinedCouponPolicy.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/JoinedCouponPolicy.java
@@ -1,0 +1,36 @@
+package com.project.imdang.member.service.domain.handler.coupon.policy;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("Welcome")
+@RequiredArgsConstructor
+public class JoinedCouponPolicy implements CouponPolicy{
+    private static final Integer ISSUE_QUANTITY = 3;
+    private final MemberCouponRepository memberCouponRepository;
+
+    @Override
+    public Integer apply(Coupon coupon, Member member) {
+        validate(coupon, member);
+        return ISSUE_QUANTITY;
+    }
+
+    @Override
+    public void validate(Coupon coupon, Member member) {
+        checkReissue(coupon.getId(), member.getId());
+    }
+
+    // 재발급 검사
+    private Boolean checkReissue(CouponId couponId, MemberId memberId) {
+        if(memberCouponRepository.findByCouponIdAndMemberId(couponId, memberId).isPresent()){
+            throw new MemberCouponDomainException("Already issued Coupon!");
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/SecondCheerUpCouponPolicy.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/SecondCheerUpCouponPolicy.java
@@ -1,0 +1,44 @@
+package com.project.imdang.member.service.domain.handler.coupon.policy;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("SecondCheerUp")
+@RequiredArgsConstructor
+public class SecondCheerUpCouponPolicy implements CouponPolicy{
+
+    private static final Integer REJECT_CRITERIA = 10;
+    private static final Integer ISSUE_QUANTITY = 3;
+    private final MemberCouponRepository memberCouponRepository;
+
+    @Override
+    public Integer apply(Coupon coupon, Member member) {
+        return ISSUE_QUANTITY;
+    }
+
+    @Override
+    public void validate(Coupon coupon, Member member) {
+        checkRejectCount(member);
+        checkReissue(coupon.getId(), member.getId());
+    }
+
+    private Boolean checkReissue(CouponId couponId, MemberId memberId) {
+        if(memberCouponRepository.findByCouponIdAndMemberId(couponId, memberId).isPresent()){
+            throw new MemberCouponDomainException("Already issued Coupon!");
+        }
+        return Boolean.TRUE;
+    }
+
+    private Boolean checkRejectCount(Member member) {
+        if (member.getRejectedCount() < REJECT_CRITERIA) {
+            throw new MemberCouponDomainException("Reject Count does not meet criteria");
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/ThirdCheerUpCouponPolicy.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/handler/coupon/policy/ThirdCheerUpCouponPolicy.java
@@ -1,0 +1,47 @@
+package com.project.imdang.member.service.domain.handler.coupon.policy;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.exception.MemberCouponDomainException;
+import com.project.imdang.member.service.domain.exception.MemberNotFoundException;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import com.project.imdang.member.service.domain.ports.output.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component("ThirdCheerUp")
+@RequiredArgsConstructor
+public class ThirdCheerUpCouponPolicy implements CouponPolicy{
+    private static final Integer REJECT_CRITERIA = 20;
+    private static final Integer ISSUE_QUANTITY = 5;
+    private final MemberCouponRepository memberCouponRepository;
+
+    @Override
+    public Integer apply(Coupon coupon, Member member) {
+        return ISSUE_QUANTITY;
+    }
+
+    @Override
+    public void validate(Coupon coupon, Member member) {
+        checkRejectCount(member);
+        checkReissue(coupon.getId(), member.getId());
+    }
+
+    private Boolean checkReissue(CouponId couponId, MemberId memberId) {
+        if(memberCouponRepository.findByCouponIdAndMemberId(couponId, memberId).isPresent()){
+            throw new MemberCouponDomainException("Already issued Coupon!");
+        }
+        return Boolean.TRUE;
+    }
+
+    private Boolean checkRejectCount(Member member) {
+        if (member.getRejectedCount() < REJECT_CRITERIA) {
+            throw new MemberCouponDomainException("Reject Count does not meet criteria");
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/mapper/MemberCouponDataMapper.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/mapper/MemberCouponDataMapper.java
@@ -1,0 +1,35 @@
+package com.project.imdang.member.service.domain.mapper;
+
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.dto.coupon.IssueMemberCouponCommand;
+import com.project.imdang.member.service.domain.dto.coupon.ListMemberCouponResponse;
+import com.project.imdang.member.service.domain.dto.coupon.UseMemberCouponCommandResponse;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Component
+public class MemberCouponDataMapper {
+
+    public ListMemberCouponResponse memberCouponsToListMemberCouponResponse(List<MemberCoupon> memberCoupons) {
+        return new ListMemberCouponResponse(memberCoupons.size());
+    }
+
+    public List<MemberCoupon> issueMemberCouponCommandToMemberCoupons(Member member, Coupon coupon, Integer quantity) {
+        return IntStream.range(0, quantity)
+                .mapToObj(i -> MemberCoupon.builder()
+                        .memberId(member.getId())
+                        .couponId(coupon.getId())
+                        .used(Boolean.FALSE)
+                        .build()).collect(Collectors.toList());
+    }
+
+    public UseMemberCouponCommandResponse memberCouponToUseMemberCouponResponse(MemberCoupon memberCoupon) {
+        return new UseMemberCouponCommandResponse(memberCoupon.getId().getValue());
+    }
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/input/service/MemberCouponApplicationService.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/input/service/MemberCouponApplicationService.java
@@ -1,14 +1,22 @@
 package com.project.imdang.member.service.domain.ports.input.service;
 
+import com.project.imdang.member.service.domain.dto.coupon.*;
+
+import java.util.UUID;
+
 public interface MemberCouponApplicationService {
 
     // + count
-    void listMemberCoupon();
+    // 가지고 있는 쿠폰 개수? 조회
+    ListMemberCouponResponse listMemberCoupon(UUID memberId);
 
-    void issueMemberCoupon();
+    // 쿠폰 발행
+    void issueMemberCoupon(IssueMemberCouponCommand issueMemberCouponCommand);
 
     // requestExchange → useMemberCoupon(memberCouponId)
     // 요청 완료 (비동기) → 요청 수락 (비동기)
     // memberCoupon used 상태 변경 : 요청 시 (거절 당하면 상태 재변경 필요) vs 요청 완료 후 "수락되면"
-    void useMemberCoupon();
+    // 쿠폰 사용
+    UseMemberCouponCommandResponse useMemberCoupon(UseMemberCouponCommand useMemberCouponCommand);
+    void cancleMemberCoupon(CancleMemberCouponCommand cancleMemberCouponCommand);
 }

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/input/service/MemberCouponApplicationService.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/input/service/MemberCouponApplicationService.java
@@ -18,5 +18,5 @@ public interface MemberCouponApplicationService {
     // memberCoupon used 상태 변경 : 요청 시 (거절 당하면 상태 재변경 필요) vs 요청 완료 후 "수락되면"
     // 쿠폰 사용
     UseMemberCouponCommandResponse useMemberCoupon(UseMemberCouponCommand useMemberCouponCommand);
-    void cancleMemberCoupon(CancleMemberCouponCommand cancleMemberCouponCommand);
+    void cancleMemberCoupon(CancelMemberCouponCommand cancelMemberCouponCommand);
 }

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/output/CouponRepository.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/output/CouponRepository.java
@@ -1,0 +1,10 @@
+package com.project.imdang.member.service.domain.ports.output;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.member.service.domain.entity.Coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<Coupon> findById(CouponId couponId);
+}

--- a/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/output/MemberCouponRepository.java
+++ b/member-service/member-domain/member-application-service/src/main/java/com/project/imdang/member/service/domain/ports/output/MemberCouponRepository.java
@@ -1,0 +1,19 @@
+package com.project.imdang.member.service.domain.ports.output;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberCouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberCouponRepository {
+    List<MemberCoupon> findAllByMemberIdAndUsed(MemberId memberId, Boolean used);
+
+    List<MemberCoupon> saveAll(List<MemberCoupon> memberCoupons);
+
+    Optional<MemberCoupon> findByCouponIdAndMemberId(CouponId couponId, MemberId memberId);
+
+    Optional<MemberCoupon> findById(MemberCouponId memberCouponId);
+}

--- a/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/MemberCouponDomainService.java
+++ b/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/MemberCouponDomainService.java
@@ -1,0 +1,11 @@
+package com.project.imdang.member.service.domain;
+
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+
+import java.util.List;
+
+public interface MemberCouponDomainService {
+    void issue(MemberCoupon memberCoupon);
+    void use(MemberCoupon memberCoupon);
+    void cancle(MemberCoupon memberCoupon);
+}

--- a/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/MemberCouponDomainServiceImpl.java
+++ b/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/MemberCouponDomainServiceImpl.java
@@ -1,0 +1,20 @@
+package com.project.imdang.member.service.domain;
+
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+
+public class MemberCouponDomainServiceImpl implements MemberCouponDomainService{
+    @Override
+    public void issue(MemberCoupon memberCoupon) {
+        memberCoupon.initialize();
+    }
+
+    @Override
+    public void use(MemberCoupon memberCoupon) {
+        memberCoupon.use();
+    }
+
+    @Override
+    public void cancle(MemberCoupon memberCoupon) {
+        memberCoupon.cancle();
+    }
+}

--- a/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/entity/MemberCoupon.java
+++ b/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/entity/MemberCoupon.java
@@ -18,7 +18,7 @@ public class MemberCoupon extends BaseEntity<MemberCouponId> {
     private final MemberId memberId;
 
     // TODO - CHECK : only 사용/미사용 + 사용 취소
-    private ZonedDateTime expiredAt;
+    //private ZonedDateTime expiredAt;
 
     private String remark;  // reason
     private ZonedDateTime createdAt;
@@ -27,15 +27,19 @@ public class MemberCoupon extends BaseEntity<MemberCouponId> {
     private ZonedDateTime usedAt;
 
     @Builder
-    public MemberCoupon(MemberCouponId id, CouponId couponId, MemberId memberId, ZonedDateTime expiredAt, String remark, ZonedDateTime createdAt, Boolean used, ZonedDateTime usedAt) {
+    public MemberCoupon(MemberCouponId id, CouponId couponId, MemberId memberId, String remark, ZonedDateTime createdAt, Boolean used, ZonedDateTime usedAt) {
         setId(id);
         this.couponId = couponId;
         this.memberId = memberId;
-        this.expiredAt = expiredAt;
+//        this.expiredAt = expiredAt;
         this.remark = remark;
         this.createdAt = createdAt;
         this.used = used;
         this.usedAt = usedAt;
+    }
+
+    public void initialize() {
+        this.createdAt = ZonedDateTime.now();
     }
 
     public void use() {
@@ -44,5 +48,13 @@ public class MemberCoupon extends BaseEntity<MemberCouponId> {
         }
         this.used = Boolean.TRUE;
         this.usedAt = ZonedDateTime.now();
+    }
+
+    public void cancle() {
+        if (Boolean.FALSE.equals(used)) {
+            throw new MemberCouponDomainException("Not used memberCoupon!");
+        }
+        this.used = Boolean.FALSE;
+        this.usedAt = null;
     }
 }

--- a/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/exception/CouponDomainException.java
+++ b/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/exception/CouponDomainException.java
@@ -1,0 +1,14 @@
+package com.project.imdang.member.service.domain.exception;
+
+import com.project.imdang.domain.exception.DomainException;
+
+public class CouponDomainException extends DomainException {
+
+    public CouponDomainException(String message) {
+        super(message);
+    }
+
+    public CouponDomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/exception/CouponNotFoundException.java
+++ b/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/exception/CouponNotFoundException.java
@@ -1,0 +1,19 @@
+package com.project.imdang.member.service.domain.exception;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+
+public class CouponNotFoundException extends CouponDomainException {
+
+    public CouponNotFoundException(CouponId couponId) {
+        this(String.format("Could not find coupon[id: %s]", couponId.getValue()));
+    }
+
+    private CouponNotFoundException(String message) {
+        super(message);
+    }
+
+    private CouponNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/exception/MemberCouponNotFoundException.java
+++ b/member-service/member-domain/member-domain-core/src/main/java/com/project/imdang/member/service/domain/exception/MemberCouponNotFoundException.java
@@ -1,0 +1,18 @@
+package com.project.imdang.member.service.domain.exception;
+
+import com.project.imdang.domain.valueobject.MemberCouponId;
+
+public class MemberCouponNotFoundException extends MemberCouponDomainException {
+
+    public MemberCouponNotFoundException(MemberCouponId memberCouponId) {
+        this(String.format("Could not find memberCoupon[id: %s]", memberCouponId.getValue()));
+    }
+
+    private MemberCouponNotFoundException(String message) {
+        super(message);
+    }
+
+    private MemberCouponNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/adapter/CouponRespositoryImpl.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/adapter/CouponRespositoryImpl.java
@@ -1,0 +1,24 @@
+package com.project.imdang.member.persistence.adapter;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.member.persistence.mapper.CouponPersistenceMapper;
+import com.project.imdang.member.persistence.repository.CouponJpaRespository;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import com.project.imdang.member.service.domain.ports.output.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRespositoryImpl implements CouponRepository {
+    private final CouponJpaRespository couponJpaRespository;
+    private final CouponPersistenceMapper couponPersistenceMapper;
+
+    @Override
+    public Optional<Coupon> findById(CouponId couponId) {
+        return couponJpaRespository.findById(couponId.getValue())
+                .map(couponPersistenceMapper::couponEntityToCoupon);
+    }
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/adapter/MemberCouponRespositoryImpl.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/adapter/MemberCouponRespositoryImpl.java
@@ -1,0 +1,53 @@
+package com.project.imdang.member.persistence.adapter;
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberCouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.persistence.entity.MemberCouponEntity;
+import com.project.imdang.member.persistence.mapper.MemberCouponPersistenceMapper;
+import com.project.imdang.member.persistence.repository.MemberCouponJpaRespository;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import com.project.imdang.member.service.domain.ports.output.MemberCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberCouponRespositoryImpl implements MemberCouponRepository{
+    private final MemberCouponJpaRespository memberCouponJpaRespository;
+    private final MemberCouponPersistenceMapper memberCouponPersistenceMapper;
+    @Override
+    public List<MemberCoupon> findAllByMemberIdAndUsed(MemberId memberId, Boolean used) {
+        List<MemberCouponEntity> memberCouponEntity = memberCouponJpaRespository.findAllByMemberIdAndUsed(memberId.getValue(), used);
+        return memberCouponEntity.stream()
+                .map(memberCouponPersistenceMapper::memberCouponEntityToMemberCoupon).collect(Collectors.toList());
+    }
+
+    @Transactional
+    @Override
+    public List<MemberCoupon> saveAll(List<MemberCoupon> memberCoupons) {
+        List<MemberCouponEntity> memberCouponEntities = memberCouponJpaRespository.saveAll(memberCoupons.stream()
+                .map(memberCouponPersistenceMapper::memberCouponToMemberCouponEntity).collect(Collectors.toList()));
+        return memberCouponEntities.stream()
+                .map(memberCouponPersistenceMapper::memberCouponEntityToMemberCoupon).collect(Collectors.toList());
+    }
+
+
+    @Override
+    public Optional<MemberCoupon> findByCouponIdAndMemberId(CouponId couponId, MemberId memberId) {
+        return memberCouponJpaRespository.findByCouponIdAndMemberId(couponId.getValue(), memberId.getValue())
+                .map(memberCouponPersistenceMapper::memberCouponEntityToMemberCoupon);
+    }
+
+    @Override
+    public Optional<MemberCoupon> findById(MemberCouponId memberCouponId) {
+        return memberCouponJpaRespository.findById(memberCouponId.getValue())
+                .map(memberCouponPersistenceMapper::memberCouponEntityToMemberCoupon);
+    }
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/entity/CouponEntity.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/entity/CouponEntity.java
@@ -1,0 +1,27 @@
+package com.project.imdang.member.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "coupon")
+@Entity
+public class CouponEntity {
+
+    @Id
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+    private String name;
+    private String expirationDate;
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/entity/MemberCouponEntity.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/entity/MemberCouponEntity.java
@@ -1,0 +1,41 @@
+package com.project.imdang.member.persistence.entity;
+
+
+import com.project.imdang.domain.valueobject.CouponId;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "member_coupon")
+@Entity
+public class MemberCouponEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID couponId;
+
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID memberId;
+
+    //현재는 사용기한 없음
+    //private ZonedDateTime expiredAt;
+
+    private String remark;  // reason
+    private ZonedDateTime createdAt;
+
+    private Boolean used;
+    private ZonedDateTime usedAt;
+
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/entity/MemberEntity.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/entity/MemberEntity.java
@@ -2,17 +2,15 @@ package com.project.imdang.member.persistence.entity;
 
 import com.project.imdang.member.service.domain.valueobject.Gender;
 import com.project.imdang.member.service.domain.valueobject.OAuthType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.util.UUID;
 
@@ -25,6 +23,8 @@ import java.util.UUID;
 public class MemberEntity {
 
     @Id
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
     private UUID id;
 
     private String authId;

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/mapper/CouponPersistenceMapper.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/mapper/CouponPersistenceMapper.java
@@ -1,0 +1,25 @@
+package com.project.imdang.member.persistence.mapper;
+
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.member.persistence.entity.CouponEntity;
+import com.project.imdang.member.service.domain.entity.Coupon;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CouponPersistenceMapper {
+    public CouponEntity CouponToCouponEntity(Coupon coupon) {
+        return CouponEntity.builder()
+                .name(coupon.getName())
+                .expirationDate(coupon.getExpirationDate())
+                .build();
+    }
+
+    public Coupon couponEntityToCoupon(CouponEntity couponEntity) {
+        return Coupon.builder()
+                .id(new CouponId(couponEntity.getId()))
+                .name(couponEntity.getName())
+                .expirationDate(couponEntity.getExpirationDate())
+                .build();
+    }
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/mapper/MemberCouponPersistenceMapper.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/mapper/MemberCouponPersistenceMapper.java
@@ -1,0 +1,37 @@
+package com.project.imdang.member.persistence.mapper;
+
+
+import com.project.imdang.domain.valueobject.CouponId;
+import com.project.imdang.domain.valueobject.MemberCouponId;
+import com.project.imdang.domain.valueobject.MemberId;
+import com.project.imdang.member.persistence.entity.MemberCouponEntity;
+import com.project.imdang.member.persistence.entity.MemberEntity;
+import com.project.imdang.member.service.domain.entity.Member;
+import com.project.imdang.member.service.domain.entity.MemberCoupon;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberCouponPersistenceMapper {
+    public MemberCouponEntity memberCouponToMemberCouponEntity(MemberCoupon memberCoupon) {
+        return MemberCouponEntity.builder()
+                .couponId(memberCoupon.getCouponId().getValue())
+                .memberId(memberCoupon.getMemberId().getValue())
+                .createdAt(memberCoupon.getCreatedAt())
+                .used(memberCoupon.getUsed())
+                .remark(memberCoupon.getRemark())
+                .usedAt(memberCoupon.getUsedAt())
+                .build();
+    }
+
+    public MemberCoupon memberCouponEntityToMemberCoupon(MemberCouponEntity memberCouponEntity) {
+        return MemberCoupon.builder()
+                .id(new MemberCouponId(memberCouponEntity.getId()))
+                .couponId(new CouponId(memberCouponEntity.getCouponId()))
+                .memberId(new MemberId(memberCouponEntity.getMemberId()))
+                .createdAt(memberCouponEntity.getCreatedAt())
+                .used(memberCouponEntity.getUsed())
+                .remark(memberCouponEntity.getRemark())
+                .usedAt(memberCouponEntity.getUsedAt())
+                .build();
+    }
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/repository/CouponJpaRespository.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/repository/CouponJpaRespository.java
@@ -1,0 +1,11 @@
+package com.project.imdang.member.persistence.repository;
+
+import com.project.imdang.member.persistence.entity.CouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CouponJpaRespository extends JpaRepository<CouponEntity, UUID> {
+    Optional<CouponEntity> findById(UUID couponId);
+}

--- a/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/repository/MemberCouponJpaRespository.java
+++ b/member-service/member-persistence/src/main/java/com/project/imdang/member/persistence/repository/MemberCouponJpaRespository.java
@@ -1,0 +1,13 @@
+package com.project.imdang.member.persistence.repository;
+
+import com.project.imdang.member.persistence.entity.MemberCouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MemberCouponJpaRespository extends JpaRepository<MemberCouponEntity, Long> {
+    List<MemberCouponEntity> findAllByMemberIdAndUsed(UUID memberId, Boolean used);
+    Optional<MemberCouponEntity> findByCouponIdAndMemberId(UUID couponId, UUID memberId);
+}


### PR DESCRIPTION
### 전달 사항
- 요청 취소 시 쿠폰 재사용은 일단 API로 따로 만들었습니다. 이벤트 발생 로직이 들어가면 아마 수정하지 않을까 싶습니다.
- 민호님께 여쭤보니 현재 쿠폰 목록 / 쿠폰 상세 정보를 확인할 수 있는 기능은 없다고 합니다.(추후 확장 예정) 그래서 조회 후 개수만 반환하고 있습니다 
- 말씀하신 대로 CouponPolicy를 한 번 적용해봤습니다! 개인적으로는 가장 깔끔한 방법인 것 같습니다(확장성 등등 고려했을때). 감사합니다!!
- 테스트는 TestConfiguration을 하나 만든 후 통합 테스트로 진행했습니다. (통합으로 할지, 단위로 할지 정해야 할 것 같습니다)

### 이어서
- security 작업
- 약관, 알람 swagger